### PR TITLE
Add dungeon generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+*.sw[op]

--- a/src/closure/core.clj
+++ b/src/closure/core.clj
@@ -1,7 +1,8 @@
 (ns closure.core
   (:require [lanterna.screen :as s]
             [clojure.tools.logging :as log]
-            [closure.cell :as cell]))
+            [closure.cell :as cell]
+            [closure.dungeon :as dungeon]))
 
 (def sigil {:oob   " ",
             :empty ".",
@@ -20,9 +21,17 @@
 ;; Main overworld
 (def mploc [1 1])
 (def mprot {:kind :prot})
-(def mgrid [[:oob (cell/new) (cell/new) (cell/new) :oob]
-            [(cell/new) (cell/new mprot) (cell/new) (cell/new) (cell/new)]
-            [:oob (cell/new) (cell/new) (cell/new) :oob]])
+
+(def grid-info
+  {:width 50
+   :height 50})
+
+(defn place-prot []
+  (let [[filled-indices dungeon] (dungeon/generate-dungeon
+                                   (:height grid-info)
+                                   (:width grid-info))
+        random-start (rand-nth (seq filled-indices))]
+      [random-start (assoc-in dungeon random-start (cell/new mprot))]))
 
 (defmulti cell-status identity)
 (defmethod cell-status :oob [_]
@@ -67,7 +76,8 @@
 
 (defn main
   [screen-type]
-  (let [screen (s/get-screen screen-type)]
+  (let [screen (s/get-screen screen-type)
+        [mploc mgrid] (place-prot)]
     (s/in-screen screen
                  (loop [[grid ploc :as state] [mgrid mploc]]
                    (draw grid screen [0 0])

--- a/src/closure/dungeon.clj
+++ b/src/closure/dungeon.clj
@@ -1,0 +1,28 @@
+(ns closure.dungeon
+  (:require [closure.cell :as cell]))
+
+(defn- get-adjacencies [row col]
+  [[(inc row) col] [(dec row) col]
+   [row (inc col)] [row (dec col)]])
+
+(defn- get-next-cell [dungeon filled-indices]
+  (let 
+    [available-cells (set
+                       (apply concat
+                        (for [[row col] filled-indices
+                              :let [adjacencies (get-adjacencies row col)]]
+                          (filter #(= :oob (get-in dungeon %)) adjacencies))))]
+     (rand-nth (seq available-cells))))
+
+(defn generate-dungeon [height width]
+  (let 
+    [empty-dungeon (vec (repeat height (vec (repeat width :oob))))
+     seed [(rand-nth (range width)) (rand-nth (range height))]
+     starting-dungeon (assoc-in empty-dungeon seed (cell/new))]
+    (loop [dungeon starting-dungeon
+           filled #{seed}]
+      (if (> (count filled) (* 0.75 height width))
+        [filled dungeon]
+        (let [cell (get-next-cell dungeon filled)
+              new-dungeon (assoc-in dungeon cell (cell/new))]
+          (recur new-dungeon (conj filled cell)))))))


### PR DESCRIPTION
Generates random dungeons by seeding a random spot on the grid, then adding adjacent tiles until the desired fill threshold is reached.
